### PR TITLE
Download full playlist on artwork error

### DIFF
--- a/TIDALDL-PY/tidal_dl/download.py
+++ b/TIDALDL-PY/tidal_dl/download.py
@@ -474,10 +474,16 @@ class Download(object):
                     fileType = self._getSongExtension(streamInfo['url'])
                     filePath = targetDir + '/' + pathHelper.replaceLimitChar(item['title'], '-') + fileType
                     aAlbumInfo = self.tool.getAlbum(item['album']['id'])
-                    coverPath = targetDir + '/' + pathHelper.replaceLimitChar(aAlbumInfo['title'], '-') + '.jpg'
-                    coverUrl  = self.tool.getAlbumArtworkUrl(aAlbumInfo['cover'])
-                    netHelper.downloadFile(coverUrl, coverPath)
-                    paraList = {'album': aAlbumInfo, 'index': index, 'title': item['title'], 'trackinfo': item, 'url': streamInfo['url'], 'path': filePath, 'retry': 3, 'key': streamInfo['encryptionKey'], 'coverpath': coverPath}
+                    paraList = {'album': aAlbumInfo, 'index': index, 'title': item['title'], 'trackinfo': item, 'url': streamInfo['url'], 'path': filePath, 'retry': 3, 'key': streamInfo['encryptionKey']}
+
+                    try:
+                        coverPath = targetDir + '/' + pathHelper.replaceLimitChar(aAlbumInfo['title'], '-') + '.jpg'
+                        coverUrl  = self.tool.getAlbumArtworkUrl(aAlbumInfo['cover'])
+                        netHelper.downloadFile(coverUrl, coverPath)
+                        paraList['coverpath'] = coverPath
+                    except:
+                        cmdHelper.myprint("Could not download artwork for '{}'".format(item['title']), cmdHelper.TextColor.Red, None)
+
                     self.check.addPath(filePath)
                     # if not os.path.isfile(filePath):
                     self.thread.start(self.__thradfunc_dl, paraList)


### PR DESCRIPTION
Failure to download artwork for a single playlist entry cancels all subsequent songs download. This patch fixes the issue by catching errors and printing a message instead.

```
Traceback (most recent call last):bel (Album Version).flac)
  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "tidal_dl/__main__.py", line 7, in <module>
    tidal_dl.main(sys.argv)
  File "./tidal_dl/__init__.py", line 174, in main
    dl.downloadPlaylist()
  File "./tidal_dl/download.py", line 478, in downloadPlaylist
    coverUrl  = self.tool.getAlbumArtworkUrl(aAlbumInfo['cover'])
  File "./tidal_dl/tidal.py", line 278, in getAlbumArtworkUrl
    return 'https://resources.tidal.com/images/{0}/{1}x{1}.jpg'.format(coverid.replace('-', '/'), size)
AttributeError: 'NoneType' object has no attribute 'replace' 
```