### PR TITLE
Fix for artist download by file

### DIFF
--- a/TIDALDL-PY/tidal_dl/__init__.py
+++ b/TIDALDL-PY/tidal_dl/__init__.py
@@ -135,7 +135,7 @@ def setting():
 
     status5 = myinputInt("Download playlist songs in artist folder structure? (0-No,1-Yes):".ljust(12), 0)
     status6 = myinputInt("Add explicit tag to file names(0-No, 1-Yes):".ljust(12), 0)
-    status7 = myinputInt("Download artist album include singles(0-No, 1-Yes):".ljust(12), 0)
+    status7 = myinputInt("Include singles and EPs when downloading an artist's albums (0-No, 1-Yes):".ljust(12), 0)
     status8 = myinputInt("Save covers(0-No, 1-Yes):".ljust(12), 0)
 
     cf.set_outputdir(outputdir)

--- a/TIDALDL-PY/tidal_dl/download.py
+++ b/TIDALDL-PY/tidal_dl/download.py
@@ -694,7 +694,8 @@ class Download(object):
             print(index)
             print("----Artist[{0}/{1}]----".format(index+1, len(arr['artist'])))
             print("[ID]          %s" % (item))
-            self.downloadArtistAlbum(self.config.includesingle, item)
+            includeSingles = self.config.includesingle == "True"
+            self.downloadArtistAlbum(includeSingles, item)
         for index, item in enumerate(arr['track']):
             print("----Track[{0}/{1}]----".format(index+1, len(arr['track'])))
             print("[ID]                %s" % (item))


### PR DESCRIPTION
This PR clarifies the english on a setting, and makes a change to respect the setting for including singles when downloading an artist's album. Previously, a string was being passed instead of a boolean, so it was being evaluated as True in all cases.