### PR TITLE
Fixed favorites replacing same name songs

### DIFF
--- a/TIDALDL-PY/tidal_dl/tidal.py
+++ b/TIDALDL-PY/tidal_dl/tidal.py
@@ -267,6 +267,7 @@ class TidalTool(object):
 
     def getFavorite(self, user_id):
         trackList = self.__getItemsList('users/' + str(user_id) + '/favorites/tracks')
+        tracklist = self._fixSameTrackName(trackList, True)
         videoList = self.__getItemsList('users/' + str(user_id) + '/favorites/videos')
         return trackList, videoList
 


### PR DESCRIPTION
Fixes #157 - When downloading songs from favorites, tracks with same name got overwritten. I just used the same function that fixes this for playlists. Videos in favorites are not fixed though.