### PR TITLE
fix albums with space in name

### DIFF
--- a/TIDALDL-PY/tidal_dl/tidal.py
+++ b/TIDALDL-PY/tidal_dl/tidal.py
@@ -260,7 +260,9 @@ class TidalTool(object):
         return item
 
     def getAlbum(self, album_id):
-        return self._get('albums/' + str(album_id))
+        item = self._get('albums/' + str(album_id))
+        item['title'] = item['title'].strip()
+        return item
 
     def getVideo(self, video_id):
         return self._get('videos/' + str(video_id))


### PR DESCRIPTION
some albums have spaces in the name. this fixes that issue.

This was reported in #210, and I've noticed it's because the Tidal API responds with those albums like that. 

Example:
```
"album":{
   "id":136874607,
   "title":"Optometry ",
```