### PR TITLE
Tidal-DL Now looks in the home folder for the config files instead of the current directory

### DIFF
--- a/TIDALDL-PY/tidal_dl/__init__.py
+++ b/TIDALDL-PY/tidal_dl/__init__.py
@@ -22,7 +22,7 @@ from aigpy.pipHelper import getLastVersion
 from aigpy.versionHelper import cmpVersion
 
 from tidal_dl.tidal import TidalAPI
-from tidal_dl.settings import Settings, UserSettings
+from tidal_dl.settings import Settings, TokenSettings
 from tidal_dl.printf import Printf, VERSION
 from tidal_dl.download import start
 from tidal_dl.enum import AudioQuality, VideoQuality
@@ -30,10 +30,10 @@ from tidal_dl.lang.language import getLang, setLang, initLang
 
 ssl._create_default_https_context = ssl._create_unverified_context
 
-API = TidalAPI()
-USER = UserSettings.read()
-CONF = Settings.read()
-LANG = initLang(CONF.language)
+API   = TidalAPI()
+TOKEN = TokenSettings.read()
+CONF  = Settings.read()
+LANG  = initLang(CONF.language)
 
 def displayTime(seconds, granularity=2):
     result = []
@@ -77,39 +77,39 @@ def login():
             break
         if check == True:
             Printf.success(LANG.MSG_VALID_ACCESSTOKEN.format(displayTime(int(API.key.expiresIn))))
-            USER.userid = API.key.userId
-            USER.countryCode = API.key.countryCode
-            USER.accessToken = API.key.accessToken
-            USER.refreshToken = API.key.refreshToken
-            USER.expiresAfter = time.time() + int(API.key.expiresIn)
-            UserSettings.save(USER)
+            TOKEN.userid = API.key.userId
+            TOKEN.countryCode = API.key.countryCode
+            TOKEN.accessToken = API.key.accessToken
+            TOKEN.refreshToken = API.key.refreshToken
+            TOKEN.expiresAfter = time.time() + int(API.key.expiresIn)
+            TokenSettings.save(TOKEN)
             break
     if elapsed >= API.key.authCheckTimeout:
     	Printf.err(LANG.AUTH_TIMEOUT)
     return
 
 def checkLogin():
-    if not isNull(USER.accessToken):
+    if not isNull(TOKEN.accessToken):
         #print('Checking Access Token...') #add to translations
-        msg, check = API.verifyAccessToken(USER.accessToken)
+        msg, check = API.verifyAccessToken(TOKEN.accessToken)
         if check == True:
-            Printf.info(LANG.MSG_VALID_ACCESSTOKEN.format(displayTime(int(USER.expiresAfter - time.time()))))
+            Printf.info(LANG.MSG_VALID_ACCESSTOKEN.format(displayTime(int(TOKEN.expiresAfter - time.time()))))
             return
         else:
             Printf.info(LANG.MSG_INVAILD_ACCESSTOKEN)
-            msg, check = API.refreshAccessToken(USER.refreshToken)
+            msg, check = API.refreshAccessToken(TOKEN.refreshToken)
             if check == True:
                 Printf.success(LANG.MSG_VALID_ACCESSTOKEN.format(displayTime(int(API.key.expiresIn))))
-                USER.userid = API.key.userId
-                USER.countryCode = API.key.countryCode
-                USER.accessToken = API.key.accessToken
-                USER.expiresAfter = time.time() + int(API.key.expiresIn)
-                UserSettings.save(USER)
+                TOKEN.userid = API.key.userId
+                TOKEN.countryCode = API.key.countryCode
+                TOKEN.accessToken = API.key.accessToken
+                TOKEN.expiresAfter = time.time() + int(API.key.expiresIn)
+                TokenSettings.save(TOKEN)
                 return
             else:
                 Printf.err(msg)
-                tmp = UserSettings()	#clears saved tokens
-                UserSettings.save(tmp)
+                tmp = TokenSettings()	#clears saved tokens
+                TokenSettings.save(tmp)
     login()
     return
         
@@ -204,7 +204,7 @@ def mainCommand():
             return
         if opt in ('-l', '--link'):
             checkLogin()
-            start(USER, CONF, val)
+            start(TOKEN, CONF, val)
             return
         if opt in ('-o', '--output'):
             CONF.downloadPath = val
@@ -249,7 +249,7 @@ def main():
         elif choice == "2":
             changeSettings()
         else:
-            start(USER, CONF, choice)
+            start(TOKEN, CONF, choice)
 
 if __name__ == "__main__":
     main()

--- a/TIDALDL-PY/tidal_dl/__init__.py
+++ b/TIDALDL-PY/tidal_dl/__init__.py
@@ -2,9 +2,9 @@
 # -*- encoding: utf-8 -*-
 '''
 @File    :   __init__.py
-@Time    :   2020/11/06
+@Time    :   2020/11/08
 @Author  :   Yaronzz
-@Version :   2.0
+@Version :   2.1
 @Contact :   yaronhuang@foxmail.com
 @Desc    :   
 '''

--- a/TIDALDL-PY/tidal_dl/settings.py
+++ b/TIDALDL-PY/tidal_dl/settings.py
@@ -6,15 +6,14 @@
 @Author  :   Yaronzz
 @Version :   1.1
 @Contact :   yaronhuang@foxmail.com
-@Desc    :   
+@Desc    :
 '''
 import json
 import base64
+import os
 from aigpy.fileHelper import getFileContent, write
 from aigpy.modelHelper import dictToModel, modelToDict
 from tidal_dl.enum import AudioQuality, VideoQuality
-
-
 
 def __encode__(string):
     sw = bytes(string, 'utf-8')
@@ -29,7 +28,7 @@ def __decode__(string):
     except:
         return string
 
-class UserSettings(object):
+class TokenSettings(object):
     userid = None
     countryCode = None
     accessToken = None
@@ -38,20 +37,27 @@ class UserSettings(object):
 
     @staticmethod
     def read():
-        txt = getFileContent('./usersettings.json', True)
+        txt = ""
+        if "XDG_CONFIG_HOME" in os.environ:
+            txt = getFileContent(os.environ['XDG_CONFIG_HOME'] + '/.tidal-dl.token.json', True)
+        else:
+            txt = getFileContent(os.environ['HOME'] + '/.tidal-dl.token.json', True)
         if txt == "":
-            return UserSettings()
+            return TokenSettings()
         txt = __decode__(txt)
         data = json.loads(txt)
-        ret = dictToModel(data, UserSettings())
+        ret = dictToModel(data, TokenSettings())
         return ret
-    
+
     @staticmethod
     def save(model):
         data = modelToDict(model)
         txt = json.dumps(data)
         txt = __encode__(txt)
-        write('./usersettings.json', txt, 'wb')
+        if "XDG_CONFIG_HOME" in os.environ:
+            write(os.environ['XDG_CONFIG_HOME'] + '/.tidal-dl.token.json', txt, 'wb')
+        else:
+            write(os.environ['HOME'] + '/.tidal-dl.token.json', txt, 'wb')
 
 class Settings(object):
     downloadPath = "./download/"
@@ -77,14 +83,18 @@ class Settings(object):
     @staticmethod
     def getDefualtAlbumFolderFormat():
         return R"{ArtistName}/{Flag} {AlbumTitle} [{AlbumID}] [{AlbumYear}]"
-    
+
     @staticmethod
     def getDefualtTrackFileFormat():
         return R"{TrackNumber} - {ArtistName} - {TrackTitle}{ExplicitFlag}"
 
     @staticmethod
     def read():
-        txt = getFileContent('./settings.json')
+        txt = ""
+        if "XDG_CONFIG_HOME" in os.environ:
+            txt = getFileContent(os.environ['XDG_CONFIG_HOME'] + '/.tidal-dl.json', True)
+        else:
+            txt = getFileContent(os.environ['HOME'] + '/.tidal-dl.json', True)
         if txt == "":
             return Settings()
         data = json.loads(txt)
@@ -106,6 +116,10 @@ class Settings(object):
         data['videoQuality'] = model.videoQuality.name
         txt = json.dumps(data)
         write('./settings.json', txt, 'w+')
+        if "XDG_CONFIG_HOME" in os.environ:
+            write(os.environ['XDG_CONFIG_HOME'] + '/.tidal-dl.json', txt, 'w+')
+        else:
+            write(os.environ['HOME'] + '/.tidal-dl.json', txt, 'w+')
 
     @staticmethod
     def getAudioQuality(value):

--- a/TIDALDL-PY/tidal_dl/settings.py
+++ b/TIDALDL-PY/tidal_dl/settings.py
@@ -2,9 +2,9 @@
 # -*- encoding: utf-8 -*-
 '''
 @File    :   settings.py
-@Time    :   2020/11/05
+@Time    :   2020/11/08
 @Author  :   Yaronzz
-@Version :   1.1
+@Version :   2.0
 @Contact :   yaronhuang@foxmail.com
 @Desc    :
 '''


### PR DESCRIPTION
Motivation: I'm in my Terminal a ton, usually with half a dozen different current directories, starting up Tidal-DL, and being prompted to re-entire my settings for the millionth time is very annoying.

Also renamed the config setting files so they're easier to identify:

usersettings.json is now .tidal-dl.json

settings.json is now .tidal-dl.token.json

----

I've tested the changes on my Mac and everything works, I don't foresee there being any issues due to this change.

The only  annoyance I can foresee is users needing to move and rename their settings, I considered writing a helper script to do that automatically.

but with the way Tidal-dl previously had no consistent path for settings.json and usersettings.json, and with how vague those file names are, I decided it could potentially cause more trouble than it's worth.