### PR TITLE
Settings: Restore default album and track file format by typing "default", and don't do anything if nothing is entered

### DIFF
--- a/TIDALDL-PY/tidal_dl/__init__.py
+++ b/TIDALDL-PY/tidal_dl/__init__.py
@@ -173,13 +173,17 @@ def changeSettings():
     CONF.language = Printf.enter(LANG.CHANGE_LANGUAGE +
                                  "('0'-English,'1'-中文,'2'-Turkish,'3'-Italiano,'4'-Czech,'5'-Arabic,'6'-Russian,'7'-Filipino,'8'-Croatian,'9'-Spanish,'10'-Portuguese,'11'-Ukrainian,'12'-Vietnamese,'13'-French,'14'-German):")
     albumFolderFormat = Printf.enter(LANG.CHANGE_ALBUM_FOLDER_FORMAT)
-    if albumFolderFormat == '0':
-        albumFolderFormat = CONF.albumFolderFormat
+    if albumFolderFormat == '0' or isNull(albumFolderFormat):
+        pass
+    elif albumFolderFormat.lower() == 'default':
+        CONF.albumFolderFormat = Settings.getDefualtAlbumFolderFormat()
     else:
         CONF.albumFolderFormat = albumFolderFormat
     trackFileFormat = Printf.enter(LANG.CHANGE_TRACK_FILE_FORMAT)
-    if trackFileFormat == '0':
-        trackFileFormat = CONF.trackFileFormat
+    if trackFileFormat == '0' or isNull(trackFileFormat):
+        pass
+    elif trackFileFormat.lower() == "default":
+        CONF.trackFileFormat = Settings.getDefualtTrackFileFormat()
     else:
         CONF.trackFileFormat = trackFileFormat
 

--- a/TIDALDL-PY/tidal_dl/lang/english.py
+++ b/TIDALDL-PY/tidal_dl/lang/english.py
@@ -60,14 +60,14 @@ class LangEnglish(object):
     CHANGE_ADD_HYPHEN = "Use hyphens instead of spaces in file names('0'-No,'1'-Yes):"
     CHANGE_ADD_YEAR = "Add year to album folder names('0'-No,'1'-Yes):"
     CHANGE_USE_TRACK_NUM = "Add track number before file names('0'-No,'1'-Yes):"
-    CHANGE_CHECK_EXIST = "Check exist file befor download track('0'-No,'1'-Yes):"
+    CHANGE_CHECK_EXIST = "Check exist file before download track('0'-No,'1'-Yes):"
     CHANGE_ARTIST_BEFORE_TITLE = "Add artistName before track title('0'-No,'1'-Yes):"
     CHANGE_INCLUDE_EP = "Include singles and EPs when downloading an artist's albums('0'-No,'1'-Yes):"
     CHANGE_ALBUMID_BEFORE_FOLDER = "Add id before album folder('0'-No,'1'-Yes):"
     CHANGE_SAVE_COVERS = "Save covers('0'-No,'1'-Yes):"
     CHANGE_LANGUAGE = "Select language"
-    CHANGE_ALBUM_FOLDER_FORMAT = "Album folder format('0' not modify):"
-    CHANGE_TRACK_FILE_FORMAT = "Track file format('0' not modify):"
+    CHANGE_ALBUM_FOLDER_FORMAT = "Album folder format('0' not modify,'default' to set default):"
+    CHANGE_TRACK_FILE_FORMAT = "Track file format('0' not modify,'default' to set default):"
     CHANGE_SHOW_PROGRESS = "Show progress('0'-No,'1'-Yes):"
     
     # {} are required in these strings


### PR DESCRIPTION
This PR  affects the following settings:

* Album folder format
* Track file format

On those 2 settings, if nothing was typed, TIDAL-DL would erase the setting. This PR will prevent this from happening.

Second, this PR allows the user to type `default` on those 2 options to restore the settings shall they want the option to have the default strings.

Example:
```
Album folder format('0' not modify,'default' to set default):default
Track file format('0' not modify,'default' to set default):default
```

Will restore the default strings.