### PR TITLE
Trim album path

### DIFF
--- a/TIDALDL-PY/tidal_dl/download.py
+++ b/TIDALDL-PY/tidal_dl/download.py
@@ -105,6 +105,19 @@ def __convertToM4a__(filepath, codec):
     os.rename(filepath, newpath)
     return newpath
 
+def __stripPathParts__(stripped_path, separator):
+    result = ""
+    stripped_path = stripped_path.split(separator)
+    for stripped_path_part in stripped_path:
+        result += stripped_path_part.strip()
+        if not stripped_path.index(stripped_path_part) == len(stripped_path) - 1:
+            result += separator
+    return result.strip()
+
+def __stripPath__(path):
+    result = __stripPathParts__(path, "/")
+    result = __stripPathParts__(result, "\\")
+    return result.strip()
 
 # "{ArtistName}/{Flag} [{AlbumID}] [{AlbumYear}] {AlbumTitle}"
 def __getAlbumPath__(conf: Settings, album):
@@ -134,7 +147,7 @@ def __getAlbumPath__(conf: Settings, album):
     retpath = retpath.replace(R"{AlbumID}", sid)
     retpath = retpath.replace(R"{AlbumYear}", year)
     retpath = retpath.replace(R"{AlbumTitle}", albumname.strip())
-    retpath = retpath.strip()
+    retpath = __stripPath__(retpath.strip())
     return base + retpath
 
 


### PR DESCRIPTION
The default album path is `Artist/ Album`. 

If there's a flag, the path is fine: ex `Artist/[ME] Album`

But if there's no flag, then the path would be `Artist/ Album` <- notice the whitespace before `Album`.

This MR adds a function that will trim just the album formatted string. It does not trim the whole download path, to prevent issues, but will solve that whitespace issue, so the resulting string is `Artist/Album` <- notice no white space.