### PR TITLE
Fix for track file format reset

### DIFF
--- a/TIDALDL-PY/tidal_dl/__init__.py
+++ b/TIDALDL-PY/tidal_dl/__init__.py
@@ -215,7 +215,7 @@ def changeSettings():
     if trackFileFormat == '0' or isNull(trackFileFormat):
         pass
     elif trackFileFormat.lower() == "default":
-        CONF.trackFileFormat = Settings.getDefaultAlbumFolderFormat()
+        CONF.trackFileFormat = Settings.getDefaultTrackFileFormat()
     else:
         CONF.trackFileFormat = trackFileFormat
 


### PR DESCRIPTION
I noticed that using `default` to reset the track file format in settings was incorrectly resetting to the album folder format. This PR corrects the oversight.

Thank you!