### PR TITLE
Save covers when downloading songs from playlists into album folders.

### DIFF
--- a/TIDALDL-PY/tidal_dl/download.py
+++ b/TIDALDL-PY/tidal_dl/download.py
@@ -460,6 +460,8 @@ def __playlist__(conf, obj):
         mag, album = API.getAlbum(item.album.id)
         item.trackNumberOnPlaylist = index + 1
         __downloadTrack__(conf, item, album, obj)
+        if conf.saveCovers and not conf.usePlaylistFolder:
+            __downloadCover__(conf,album)
     for item in videos:
         __downloadVideo__(conf, item, None)
 


### PR DESCRIPTION
If the option for saving covers is set to true and the playlist folder is not used, songs are saved according to their album. In this case album covers would now be saved too.