### PR TITLE
Add nightly build for tidal-dl and update README.md

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -1,0 +1,40 @@
+name: Tidal Media Downloader
+
+on: [push, pull_request]
+
+jobs:
+  Build:
+    name: Build tidal-dl
+    runs-on: windows-2022
+
+    steps:
+    - name: Checkout Tidal-Media-Downloader repo
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Install build dependencies
+      run: |
+        pip3 install wheel
+        pip3 install pyinstaller
+        pip3 install PyQt5
+        pip3 install -r requirements.txt --upgrade
+      working-directory: TIDALDL-PY
+
+    - name: Clean exe directory
+      run: |
+        rm -force exe/tidal-dl.exe
+      working-directory: TIDALDL-PY
+      
+    - name: Build tidal-dl artifact
+      run: |
+        python setup.py sdist bdist_wheel
+        pyinstaller -F tidal_dl/__init__.py
+        mv dist/__init__.exe exe/tidal-dl.exe
+      working-directory: TIDALDL-PY       
+      
+    - name: Upload tidal-dl artifact
+      uses: actions/upload-artifact@v2
+      with: 
+        name: tidal-dl
+        path: ${{ github.workspace }}\TIDALDL-PY\exe\tidal-dl.exe

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@
 | tidal-gui      | Windows                           | [GUI Repository](https://github.com/yaronzz/Tidal-Media-Downloader-PRO) |
 | tidal-dl (cli) | Windows \ Linux \ Macos \ Android | ```pip3 install tidal-dl --upgrade```<br />[Detailed Description](https://yaronzz.com/post/tidal_dl_installation/#Install) |
 
+### Nightly Builds
+
+|Download nightly builds from continuous integration: 	| [![Build Status][Build]][Actions] 
+|-------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+
+[Actions]: https://github.com/yaronzz/Tidal-Media-Downloader/actions
+[Build]: https://github.com/yaronzz/Tidal-Media-Downloader/workflows/Tidal%20Media%20Downloader/badge.svg
+
 ## 📡 Telegram
 
 - [Group](https://t.me/tidal_group) : Feed back


### PR DESCRIPTION
Hi @yaronzz this PR adds a Github Workflow CI/CD pipeline for nightly builds for the tidal-dl software.

When you add something to the master repository or someone else opens a PR a build will start to run.

Here you can see a succesful run, this is located under the Actions tab of you repository:
https://github.com/bladeoner/Tidal-Media-Downloader/actions/runs/1906271443

When you click on 'tidal-dl' you can see the details of the build.

It also uploads an artifiact which can be downloaded, here is an example:
https://github.com/bladeoner/Tidal-Media-Downloader/actions/runs/1906271443

I also added an Nightly Build section in the README.md where you can see the status of the last build and which can be used to go to the build runs to download the artifact.
https://github.com/bladeoner/Tidal-Media-Downloader/tree/workflow
