### PR TITLE
for playlist dl, perform deletes as well as adds in the target dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,5 @@ TIDALDL-PY/exe/resource
 TIDALDL-PY/exe/tidal_dl_win.tar.gz
 .github/workflows/continuous-integration-workflow copy.yml
 TIDALDL-PY/tidal-gui.spec
+.history/
+.gitignore

--- a/README.md
+++ b/README.md
@@ -140,3 +140,19 @@ pip3 install -r requirements.txt --user
 python3 setup.py install
 ```
 
+## Fork changes - Scenario and comments:
+I would be content with TIDAL download feature, to give me off-line music on my device.  I find playlists good for that.
+
+But playlist changes are not done well.  If I add 1 song to a 100 song playlist, the only way I can get it on my phone is: -
+delete all 100 songs - download 101 songs.  It's the time, the wear and tear on my device sd card... nope... don't like it at all.
+
+But I see tidal-dl can create a "mirror image" of that playlist.  And has some smarts: if I add a song to the playlist, download again, it will ONLY download that song.  Cool.  But - what if I delete a song?
+
+Background: I use PC MediaMonkey for my non-TIDAL mp3s... it will download a music folder to my device... with MediaMonkey for Android and my home Wifi.  Of course, MM can also see tidal-dl that "mirror image" playlist.  And crucially: if there are adds/deletes, MM makes just the changes on my phone.  Other files are untouched.  Deletes are done too, smart!
+
+But... now tidal-dl is the weak link.  If I add 1 file to a playlist, and delete 1 file... it gives me the add... but it doesn't handle the delete.  And the "mirror image" is not a mirror image any more.
+
+So this is to fill that gap in my scenario.  But the effect seems useful for other use-cases.  SUMMARY: Suppose you download a playlist, on top of a previous download.  If files are deleted on the playlist, they will also be deleted in the mirror image.
+
+Also: some improved handling of the "onlyM4A" flag.  If files have been renamed from mp4 to m4a, the SKIP download logic wasn't working.  Now it's handled for the simple case at least.
+

--- a/TIDALDL-PY/tidal_dl/download.py
+++ b/TIDALDL-PY/tidal_dl/download.py
@@ -113,12 +113,31 @@ def __playlist__(conf, obj):
         Printf.err(msg)
         return
 
+    dictNewFiles = {}
     for index, item in enumerate(tracks):
         mag, album = API.getAlbum(item.album.id)
         item.trackNumberOnPlaylist = index + 1
-        downloadTrack(item, album, obj)
+        downloadTrack(item, album, obj, dictNewFiles=dictNewFiles)
         if conf.saveCovers and not conf.usePlaylistFolder:
             __downloadCover__(conf, album)
+
+    if len(dictNewFiles) > 0:
+        targetDir = aigpy.path.getDirName(dictNewFiles[list(dictNewFiles.keys())[0]]) # trick to get the target directory
+        resFiles = aigpy.path.getFiles(targetDir)
+        killFiles = []
+        errFiles = []
+
+        for fname in resFiles:
+            if not os.path.basename(fname) in dictNewFiles:
+                try:
+                    os.remove(fname)
+                    killFiles.append(fname)
+                except:
+                    errFiles.append(fname)
+
+        Printf.info("Orphan files deleted:\n" + "\n".join(killFiles))
+        Printf.info("Orphan files failed to delete (read-only?):\n" + "\n".join(errFiles))
+
     for item in videos:
         downloadVideo(item, None)
         

--- a/TIDALDL-PY/tidal_dl/download.py
+++ b/TIDALDL-PY/tidal_dl/download.py
@@ -127,16 +127,23 @@ def __playlist__(conf, obj):
         killFiles = []
         errFiles = []
 
+        def bareFnList(fullFn: str):
+            # strip ext so .m4a and corresponding .lrc are handled together
+            return os.path.splitext(os.path.basename(fullFn))[0]
+
         for fname in resFiles:
-            if not os.path.basename(fname) in dictNewFiles:
+            # strip ext so .m4a and corresponding .lrc are handled together
+            if not os.path.splitext(os.path.basename(fname))[0] in list(map(bareFnList, list(dictNewFiles.keys()))) :
                 try:
                     os.remove(fname)
                     killFiles.append(fname)
                 except:
                     errFiles.append(fname)
 
-        Printf.info("Orphan files deleted:\n" + "\n".join(killFiles))
-        Printf.info("Orphan files failed to delete (read-only?):\n" + "\n".join(errFiles))
+        if len(killFiles) > 0:
+            Printf.success("List of Orphan files deleted :\n" + "\n".join(killFiles))
+        if len(errFiles) > 0:
+            Printf.err("List of Orphan files failed to delete (read-only?) :\n" + "\n".join(errFiles))
 
     for item in videos:
         downloadVideo(item, None)


### PR DESCRIPTION
SUMMARY: Download folder of playlist is maintained as a mirror image of the playlist in TIDAL.  DETAIL: Currently with check-exist default, only pl ADDS are downloaded.  The missing piece is to handle playlist DELETES in TIDAL.  With this change, the playlist download folder is maintained as a mirror image of the current TIDAL playlist.   Not controlled by a setting, ths code works whether or not "check exists" is true.