### PR TITLE
Update Github Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -67,7 +67,7 @@ jobs:
     #   working-directory: TIDALDL-PY/dist
       
     - name: Upload artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with: 
         name: tidal-dl-${{ runner.os }}
         path: |


### PR DESCRIPTION
Hi @yaronzz  I hope you are doing fine.

There are some warnings appearing in Github Actions about moving from Node.js 12 to Node.js 16, this commit will use Node.js 16.

Thanks in advance.

Enjoy your weekend!