### PR TITLE
fix(cover): return if no cover found

### DIFF
--- a/TIDALDL-PY/tidal_dl/tidal.py
+++ b/TIDALDL-PY/tidal_dl/tidal.py
@@ -334,6 +334,8 @@ class TidalAPI(object):
         return self.__get__(f'tracks/{str(id)}/contributors')
 
     def getCoverUrl(self, sid, width="320", height="320"):
+        if sid is None:
+            return ""
         return f"https://resources.tidal.com/images/{sid.replace('-', '/')}/{width}x{height}.jpg"
 
     def getCoverData(self, sid, width="320", height="320"):


### PR DESCRIPTION
This fixes an edge case scenario when downloading an Album without a cover returning an error of `'NoneType' object has no attribute 'replace'`. The edge case occurs if the "save covers" settings is true **but** not the "use playlist folder" setting. This combination of settings bypasses the check implemented in https://github.com/yaronzz/Tidal-Media-Downloader/pull/983.